### PR TITLE
Fixes powerhell calls using dashed parameters

### DIFF
--- a/src/main/java/com/evolveum/powerhell/PowerHellWinRmLoopImpl.java
+++ b/src/main/java/com/evolveum/powerhell/PowerHellWinRmLoopImpl.java
@@ -174,7 +174,7 @@ public class PowerHellWinRmLoopImpl extends AbstractPowerHellWinRmImpl {
 			writerStdErr = new StringWriter();
 			promptMessage = null;
 			
-			outCommandLine = encodePowerShellVariablesAndCommandToString(psScript, arguments);
+			outCommandLine = createPowerShellScripWithArguments(psScript, arguments);
 			String tx = outCommandLine + "\r\n" + prompt + "\r\n";
 			logData("I>", tx);
 			


### PR DESCRIPTION
PowerHellImpl.runCommand would only allow parameters to be set correctly via variables and not dashed format by only invoking encodePowerShellVariablesAndCommandToString instead of createPowerShellScripWithArguments